### PR TITLE
Add pack current/voltage, corresponding updates to measure and console

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -741,7 +741,7 @@ void Board_CAN_ProcessInput(BMS_INPUT_T *bms_input, BMS_OUTPUT_T *bms_output) {
 #endif // FSAE_DRIVERS
 }
 
-void Board_CAN_ProcessOutput(BMS_INPUT_T *bms_input, BMS_STATE_T * bms_state, BMS_OUTPUT_T *bms_output) {
+void Board_CAN_ProcessOutput(BMS_INPUT_T *bms_input, BMS_STATE_T *bms_state, BMS_OUTPUT_T *bms_output) {
 #ifdef FSAE_DRIVERS
     Fsae_Can_Transmit(bms_input, bms_state, bms_output);
 #else // FSAE_DRIVERS

--- a/src/console.c
+++ b/src/console.c
@@ -274,7 +274,7 @@ static void config(const char * const * argv) {
 }
 
 static void measure(const char * const * argv) {
-    if (bms_state->curr_mode == BMS_SSM_MODE_STANDBY) { 
+    if (bms_state->curr_mode == BMS_SSM_MODE_STANDBY || bms_state->curr_mode == BMS_SSM_MODE_DISCHARGE) { 
         if (strcmp(argv[1],"on") == 0) {
             console_output->measure_on = true;
             Board_Println("Measure On!");
@@ -317,11 +317,9 @@ static void measure(const char * const * argv) {
 
         } else if (strcmp(argv[1],"packcurrent") == 0) {
             console_output->measure_packcurrent = !console_output->measure_packcurrent;
-            Board_Println("Not implemented yet!");
 
         } else if (strcmp(argv[1],"packvoltage") == 0) {
             console_output->measure_packvoltage = !console_output->measure_packvoltage;
-            Board_Println("Not implemented yet!");
 
         } else {
             Board_Println("Unrecognized command!");

--- a/src/fsae_drivers/fsae_can.c
+++ b/src/fsae_drivers/fsae_can.c
@@ -57,8 +57,16 @@ void Fsae_Can_Receive(BMS_INPUT_T *bms_input, BMS_OUTPUT_T *bms_output) {
         Can_Vcu_BmsHeartbeat_T msg;
         Can_Vcu_BmsHeartbeat_Read(&msg);
         bms_input->last_vcu_msg_ms = bms_input->msTicks;
+    } else if (msgType == Can_CurrentSensor_Current_Msg) {
+        Can_CurrentSensor_Current_T msg;
+        Can_CurrentSensor_Current_Read(&msg);
+        bms_input->pack_status->pack_current_mA = msg.current_mA > 0 ? msg.current_mA : -msg.current_mA;
+    } else if (msgType == Can_CurrentSensor_Voltage_Msg) {
+        Can_CurrentSensor_Voltage_T msg;
+        Can_CurrentSensor_Voltage_Read(&msg);
+        bms_input->pack_status->pack_voltage_mV = msg.voltage_mV > 0 ? msg.voltage_mV : -msg.voltage_mV;
     } else {
-        // TODO handle current messages
+        // note other errors
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -199,11 +199,13 @@ void Process_Keyboard(void) {
 }
 
 // FSAE TODO
-//   Measure while in discharge
+//   Measure while in discharge [In PR]
 //   cmd for cell stats (min/max/std/avg)
 //   Calibrate bias and temps
-//   Current sense measure integrate into BMS
-//
+//   Current sense measure integrate into BMS [In PR]
+//   contactor_closed dilemna to return state of contactors [For summer/fall clean-up]
+//   Clean up overheating board fix in charge SM and move that to board
+//   update CAN signatures to include msTicks for queueing fix...
 //
 // [TODO] Undervoltage (create error handler)           WHO:Erpo
 // [TODO] SOC error (create error handler [CAN msg])    WHO:Erpo

--- a/src/measure.c
+++ b/src/measure.c
@@ -65,11 +65,19 @@ void Output_Measurements(
         }
 
         if(console_output->measure_packcurrent) {
-            Board_Println("Not implemented!");
+            utoa(msTicks, tempstr, 10); // print msTicks
+            Board_Print_BLOCKING(tempstr);
+            Board_Print_BLOCKING(",pcurr,");
+            utoa(bms_input->pack_status->pack_current_mA, tempstr, 10);
+            Board_Println_BLOCKING(tempstr); // print pack current
         }
 
         if(console_output->measure_packvoltage) {
-            Board_Println("Not implemented!");
+            utoa(msTicks, tempstr, 10); // print msTicks
+            Board_Print_BLOCKING(tempstr);
+            Board_Print_BLOCKING(",pvolt,");
+            utoa(bms_input->pack_status->pack_voltage_mV, tempstr, 10);
+            Board_Println_BLOCKING(tempstr); // print pack voltage
         }
     }
 }


### PR DESCRIPTION
Couple changes here:

- Allowed `measure` mode while in discharge; this means you can have a stream of measurements to a log for battery science (!): cell level voltage, temperatures, pack current, pack voltage
- Now reading pack current and voltage off of corresponding CAN messages
- Courtesy of the nicely written console (thank you rango), commands to get pack current and pack voltage were already implemented.
- Added some TODOs to our large laundry list in main.c that we've been keeping since the start of the project

Accurate values of pack current/pack voltage depend on receiving timely CAN messages from the Current Sense Node (?), and hopefully using Alec's shiny CAN library properly, which has some macro trickery.